### PR TITLE
Add individual tests for each VIM plugin to verify their installation

### DIFF
--- a/tests/test_setup.bats
+++ b/tests/test_setup.bats
@@ -13,11 +13,6 @@ setup() {
   [ -L "$HOME/.gitignore_global" ]
 }
 
-@test "Check if VIM is configured correctly" {
-  run grep "Plugin 'scrooloose/nerdtree'" "$HOME/.vimrc"
-  [ "$status" -eq 0 ]
-}
-
 @test "Check if tmux is configured correctly" {
   run grep "set -g default-terminal \"screen-256color\"" "$HOME/.tmux.conf"
   [ "$status" -eq 0 ]
@@ -36,4 +31,40 @@ setup() {
 @test "Check if git is configured correctly" {
   run grep "[user]" "$HOME/.gitconfig"
   [ "$status" -eq 0 ]
+}
+
+@test "Check if nerdtree plugin directory exists" {
+  [ -d "$HOME/.vim/bundle/nerdtree" ]
+}
+
+@test "Check if vim-colors-solarized plugin directory exists" {
+  [ -d "$HOME/.vim/bundle/vim-colors-solarized" ]
+}
+
+@test "Check if vim-gitgutter plugin directory exists" {
+  [ -d "$HOME/.vim/bundle/vim-gitgutter" ]
+}
+
+@test "Check if vim-fugitive plugin directory exists" {
+  [ -d "$HOME/.vim/bundle/vim-fugitive" ]
+}
+
+@test "Check if vim-airline plugin directory exists" {
+  [ -d "$HOME/.vim/bundle/vim-airline" ]
+}
+
+@test "Check if vim-airline-themes plugin directory exists" {
+  [ -d "$HOME/.vim/bundle/vim-airline-themes" ]
+}
+
+@test "Check if ale plugin directory exists" {
+  [ -d "$HOME/.vim/bundle/ale" ]
+}
+
+@test "Check if Copilot.vim plugin directory exists" {
+  [ -d "$HOME/.vim/bundle/Copilot.vim" ]
+}
+
+@test "Check if vim-terraform plugin directory exists" {
+  [ -d "$HOME/.vim/bundle/vim-terraform" ]
 }


### PR DESCRIPTION
Remove the existing test that checks if VIM is configured correctly and add individual tests for each VIM plugin to verify their installation.

* Remove the test that checks if VIM is configured correctly by looking for a specific plugin in the `.vimrc` file.
* Add tests to check if the following VIM plugin directories exist:
  - `nerdtree`
  - `vim-colors-solarized`
  - `vim-gitgutter`
  - `vim-fugitive`
  - `vim-airline`
  - `vim-airline-themes`
  - `ale`
  - `Copilot.vim`
  - `vim-terraform`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bogdangi/env/pull/8?shareId=653e940c-8f6d-43f0-9119-86710515042b).